### PR TITLE
Update code coverage config

### DIFF
--- a/Build/Invoke-ModuleTests.ps1
+++ b/Build/Invoke-ModuleTests.ps1
@@ -13,19 +13,20 @@ Write-Host $Lines
 try {
     # Try/Finally required since we will exit with exit code on failure.
     Invoke-Pester -Configuration @{
-        Run          = @{
+        Run          = [Pester.RunConfiguration]@{
             Path = "$env:PROJECTROOT/Tests"
             Exit = $true
         }
-        CodeCoverage = @{
+        CodeCoverage = [Pester.CodeCoverageConfiguration]@{
             Enabled = $true
             Path    = Get-ChildItem -Recurse -Include '*.ps1' -Path @(
                 "$env:PROJECTROOT/PSKoans/PSKoans.psm1"
                 "$env:PROJECTROOT/PSKoans/Public"
                 "$env:PROJECTROOT/PSKoans/Private"
-            )
+            ) |
+                Select-Object -ExpandProperty FullName
         }
-        TestResult   = @{
+        TestResult   = [Pester.TestResultConfiguration]@{
             Enabled       = $true
             TestSuiteName = "PSKoans-Pester"
         }

--- a/Build/Invoke-ModuleTests.ps1
+++ b/Build/Invoke-ModuleTests.ps1
@@ -12,25 +12,19 @@ Write-Host $Lines
 
 try {
     # Try/Finally required since we will exit with exit code on failure.
-    Invoke-Pester -Configuration @{
-        Run          = [Pester.RunConfiguration]@{
-            Path = "$env:PROJECTROOT/Tests"
-            Exit = $true
-        }
-        CodeCoverage = [Pester.CodeCoverageConfiguration]@{
-            Enabled = $true
-            Path    = Get-ChildItem -Recurse -Include '*.ps1' -Path @(
-                "$env:PROJECTROOT/PSKoans/PSKoans.psm1"
-                "$env:PROJECTROOT/PSKoans/Public"
-                "$env:PROJECTROOT/PSKoans/Private"
-            ) |
-                Select-Object -ExpandProperty FullName
-        }
-        TestResult   = [Pester.TestResultConfiguration]@{
-            Enabled       = $true
-            TestSuiteName = "PSKoans-Pester"
-        }
-    }
+    $configuration = [PesterConfiguration]::Default
+    $configuration.Run.Path = "$env:PROJECTROOT/Tests"
+    $configuration.Run.Exit = $true
+    $configuration.CodeCoverage.Enabled = $true
+    $configuration.CodeCoverage.Path = Get-ChildItem -Recurse -Include '*.ps1' -Path @(
+            "$env:PROJECTROOT/PSKoans/PSKoans.psm1"
+            "$env:PROJECTROOT/PSKoans/Public"
+            "$env:PROJECTROOT/PSKoans/Private"
+        ) | Select-Object -ExpandProperty FullName 
+    $configuration.TestResult.Enabled = $true
+    $configuration.TestResult.TestSuiteName = "PSKoans-Pester
+    
+    Invoke-Pester -Configuration $configuration
 }
 finally {
     $Timestamp = Get-Date -Format "yyyyMMdd-hhmmss"

--- a/Build/Invoke-ModuleTests.ps1
+++ b/Build/Invoke-ModuleTests.ps1
@@ -11,8 +11,25 @@ Write-Host "TEST: Pester Version: $PesterVersion"
 Write-Host $Lines
 
 try {
-    # Try/Finally required since -CI will exit with exit code on failure.
-    Invoke-Pester -Path "$env:PROJECTROOT" -CI -Output Normal
+    # Try/Finally required since we will exit with exit code on failure.
+    Invoke-Pester -Configuration @{
+        Run          = @{
+            Path = "$env:PROJECTROOT/Tests"
+            Exit = $true
+        }
+        CodeCoverage = @{
+            Enabled = $true
+            Path    = Get-ChildItem -Recurse -Include '*.ps1' -Path @(
+                "$env:PROJECTROOT/PSKoans/PSKoans.psm1"
+                "$env:PROJECTROOT/PSKoans/Public"
+                "$env:PROJECTROOT/PSKoans/Private"
+            )
+        }
+        TestResult   = @{
+            Enabled       = $true
+            TestSuiteName = "PSKoans-Pester"
+        }
+    }
 }
 finally {
     $Timestamp = Get-Date -Format "yyyyMMdd-hhmmss"

--- a/Build/Invoke-ModuleTests.ps1
+++ b/Build/Invoke-ModuleTests.ps1
@@ -22,7 +22,7 @@ try {
             "$env:PROJECTROOT/PSKoans/Private"
         ) | Select-Object -ExpandProperty FullName 
     $configuration.TestResult.Enabled = $true
-    $configuration.TestResult.TestSuiteName = "PSKoans-Pester
+    $configuration.TestResult.TestSuiteName = "PSKoans-Pester"
     
     Invoke-Pester -Configuration $configuration
 }


### PR DESCRIPTION
# PR Summary

Attempt to manually configure tests for Pester v5 and add code coverage that should (hopefully) work correctly.

## Context

The automatic test coverage generation that `-CI` enables is not reading in our function files since we don't store function files alongside test files. Hopefully a more specific manual configuration should do the trick.

## Changes

- Replace `-CI` switch with manually configured `-Configuration` settings.

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [ ] Pull Request is ready to merge & is not WIP.
- [x] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
