### PR TITLE
Adds draft caching mechanism

### DIFF
--- a/PSKoans/Init/InitializeCache.ps1
+++ b/PSKoans/Init/InitializeCache.ps1
@@ -1,0 +1,9 @@
+if (-not (Test-Path -Path $Script:CachePath)) {
+    New-Item -Path $Script:CachePath -ItemType Directory > $null
+}
+
+$Script:KoanResultCache = @{}
+
+foreach ($cacheItem in Get-ChildItem $Script:CachePath -Filter *.xml) {
+    $Script:KoanResultCache[$cacheItem.BaseName] = Import-Clixml -Path $cacheItem.FullName
+}

--- a/PSKoans/PSKoans.psm1
+++ b/PSKoans/PSKoans.psm1
@@ -15,6 +15,7 @@
 
 $script:ModuleRoot = $PSScriptRoot
 $script:ConfigPath = '~/.config/PSKoans/config.json'
+$script:CachePath = '~/.config/PSKoans/cache'
 $script:DefaultSettings = @{
     KoanLocation = Resolve-Path -Path '~' | Join-Path -ChildPath 'PSKoans'
     Editor       = 'code'

--- a/PSKoans/Private/Add-KoanCachedResult.ps1
+++ b/PSKoans/Private/Add-KoanCachedResult.ps1
@@ -1,0 +1,44 @@
+function Add-KoanCachedResult {
+    <#
+    .SYNOPSIS
+        Add an entry to the koan cache.
+
+    .DESCRIPTION
+        Cache the results of running tests for this koan. This avoids the overhead of repeatedly running pester on unchanged content.
+
+    .PARAMETER Path
+        The path to the koans test file.
+
+    .PARAMETER PesterTests
+        The result of running tests against the file created by the Invoke-Koan command.
+    #>
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [Parameter(Mandatory)]
+        [object]$Result
+    )
+
+    $currentHash = (Get-FileHash -Path $Path).Hash
+    $cacheEntryName = [System.IO.Path]::GetFileNameWithoutExtension($Path)
+
+    if ($Script:KoanResultCache.Contains($cacheEntryName) -and $currentHash -eq $Script:KoanResultCache[$cacheEntryName]['Hash']) {
+        # No work to do for this file. Return immediately.
+        return
+    }
+
+    $cacheItemPath = Join-Path -Path $Script:CachePath -ChildPath (
+        '{0}.xml' -f [System.IO.Path]::GetFileNameWithoutExtension($Path)
+    )
+
+    $cacheEntry = @{
+        Hash   = $currentHash
+        Result = $Result
+    }
+    $cacheEntry | Export-CliXml -Path $cacheItemPath -Depth 5
+
+    $Script:KoanResultCache[$cacheEntryName] = $cacheEntry
+}

--- a/PSKoans/Private/Add-KoanCachedResult.ps1
+++ b/PSKoans/Private/Add-KoanCachedResult.ps1
@@ -16,10 +16,12 @@ function Add-KoanCachedResult {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]
-        [string]$Path,
+        [string]
+        $Path,
 
         [Parameter(Mandatory)]
-        [object]$Result
+        [object]
+        $Result
     )
 
     $currentHash = (Get-FileHash -Path $Path).Hash

--- a/PSKoans/Private/Get-KoanCachedResult.ps1
+++ b/PSKoans/Private/Get-KoanCachedResult.ps1
@@ -13,7 +13,8 @@ function Get-KoanCachedResult {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory)]
-        [string]$Path
+        [string]
+        $Path
     )
 
     $cacheEntryName = [System.IO.Path]::GetFileNameWithoutExtension($Path)

--- a/PSKoans/Private/Get-KoanCachedResult.ps1
+++ b/PSKoans/Private/Get-KoanCachedResult.ps1
@@ -1,0 +1,29 @@
+function Get-KoanCachedResult {
+    <#
+    .SYNOPSIS
+        Add an entry to the koan cache.
+
+    .DESCRIPTION
+        Cache the results of running tests for this koan. This avoids the overhead of repeatedly running pester on unchanged content.
+
+    .PARAMETER Path
+        The path to the koans test file.
+    #>
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    $cacheEntryName = [System.IO.Path]::GetFileNameWithoutExtension($Path)
+
+    if ($Script:KoanResultCache.ContainsKey($cacheEntryName)) {
+        $currentHash = (Get-FileHash -Path $Path).Hash
+        $cacheEntry = $Script:KoanResultCache[$cacheEntryName]
+
+        if ($currentHash -eq $cacheEntry['Hash']) {
+            $cacheEntry['Result']
+        }
+    }
+}

--- a/PSKoans/Private/Measure-Koan.ps1
+++ b/PSKoans/Private/Measure-Koan.ps1
@@ -39,7 +39,7 @@
         ) -join [System.IO.Path]::PathSeparator
     }
     process {
-        Write-Verbose "Discovering koans in [$($KoanInfo.Name -join '], [')]"
+        Write-Verbose "Discovering koans in [$($KoanInfo.Path -join '], [')]"
 
         $Result = & (Get-Module Pester) {
             [CmdletBinding()]

--- a/PSKoans/Private/New-KoanRunspace.ps1
+++ b/PSKoans/Private/New-KoanRunspace.ps1
@@ -26,12 +26,17 @@ function New-KoanRunspace {
 
     try {
         $script = {
-            param( $PSKoansPath )
+            param(
+                $PesterPath,
+                $PSKoansPath
+            )
 
+            Get-Module $PesterPath -ListAvailable | Import-Module
             Get-Module $PSKoansPath -ListAvailable | Import-Module
         }
 
         $ps.AddScript($script) > $null
+        $ps.AddParameter('PesterPath', (Get-Module Pester).ModuleBase) > $null
         $ps.AddParameter('PSKoansPath', $MyInvocation.MyCommand.Module.ModuleBase) > $null
         $ps.Invoke() > $null
 

--- a/Start-DebugSession.ps1
+++ b/Start-DebugSession.ps1
@@ -6,6 +6,10 @@ $env:PSModulePath = $(
 ) -join [System.IO.Path]::PathSeparator
 
 & $PSScriptRoot/PSKoans.ezformat.ps1
+
+$pester = Get-Module pester -ListAvailable | Where-Object Version -eq '5.0.2'
+
+Import-Module (Join-Path -Path $pester.ModuleBase -ChildPath 'pester.psd1')
 Import-Module $PSScriptRoot/PSKoans
 
-### Enter code to test below
+### Enter code to test here

--- a/Tests/Functions/Private/Add-KoanCachedResult.Tests.ps1
+++ b/Tests/Functions/Private/Add-KoanCachedResult.Tests.ps1
@@ -1,0 +1,38 @@
+#Requires -Modules PSKoans
+
+Describe 'Add-KoanCachedResult' {
+    BeforeAll {
+        Mock 'Get-FileHash' {
+            [PSCustomObject]@{
+                Hash = 'abcdef'
+            }
+        }
+        Mock 'Export-CliXml'
+    }
+
+    It 'adds an entry to the cache when the entry does not exist' {
+        InModuleScope -ModuleName 'PSKoans' {
+            $Script:KoanResultCache = @{}
+
+            Add-KoanCachedResult -Path 'AboutAssertions.Koans.ps1' -Result 'Result'
+        }
+
+        Should -Invoke 'Get-FileHash'
+        Should -Invoke 'Export-CliXml'
+    }
+
+    It 'does nothing when the cache entry already exists and hashes match' {
+        InModuleScope -ModuleName 'PSKoans' {
+            $Script:KoanResultCache = @{
+                'AboutAssertions.Koans' = @{
+                    Hash = 'abcdef'
+                }
+            }
+
+            Add-KoanCachedResult -Path 'AboutAssertions.Koans.ps1' -Result 'Result'
+        }
+
+        Should -Invoke 'Get-FileHash'
+        Should -Invoke 'Export-CliXml' -Times 0
+    }
+}

--- a/Tests/Functions/Private/Get-KoanCachedResult.Tests.ps1
+++ b/Tests/Functions/Private/Get-KoanCachedResult.Tests.ps1
@@ -1,0 +1,45 @@
+#Requires -Modules PSKoans
+
+Describe 'Get-KoanCachedResult' {
+    BeforeAll {
+        Mock 'Get-FileHash' {
+            [PSCustomObject]@{
+                Hash   = 'abcdef'
+            }
+        }
+    }
+
+    It 'gets an entry when hashes match' {
+        InModuleScope -ModuleName 'PSKoans' {
+            $Script:KoanResultCache = @{
+                'AboutAssertions.Koans' = @{
+                    Hash   = 'abcdef'
+                    Result = 'Result'
+                }
+            }
+
+            Get-KoanCachedResult -Path 'AboutAssertions.Koans.ps1'
+        } | Should -Be 'Result'
+    }
+
+    It 'returns nothing when hashes do not match' {
+        InModuleScope -ModuleName 'PSKoans' {
+            $Script:KoanResultCache = @{
+                'AboutAssertions.Koans' = @{
+                    Hash   = 'defabc'
+                    Result = 'Result'
+                }
+            }
+
+            Get-KoanCachedResult -Path 'AboutAssertions.Koans.ps1'
+        } | Should -BeNullOrEmpty
+    }
+
+    It 'returns nothing when the item is not in the cache' {
+        InModuleScope -ModuleName 'PSKoans' {
+            $Script:KoanResultCache = @{}
+
+            Get-KoanCachedResult -Path 'AboutAssertions.Koans.ps1'
+        } | Should -BeNullOrEmpty
+    }
+}

--- a/Tests/Functions/Private/Invoke-Koan.Tests.ps1
+++ b/Tests/Functions/Private/Invoke-Koan.Tests.ps1
@@ -3,6 +3,9 @@
 Describe 'Invoke-Koan' {
 
     BeforeAll {
+        Mock Add-KoanCachedResult
+        Mock Get-KoanCachedResult
+
         $testFile = @{ Script = "$PSScriptRoot/ControlTests/Invoke-Koan.Control_Tests.ps1" }
     }
 
@@ -42,5 +45,35 @@ Describe 'Invoke-Koan' {
         $Results.Tests.ErrorRecord.Exception |
             ForEach-Object -MemberName GetType |
             Should -Be @([Exception], [NotImplementedException])
+    }
+
+    Context 'item exists in cache' {
+        BeforeAll {
+            Mock Get-KoanCachedResult {
+                'CachedResult'
+            }
+        }
+
+        It 'returns a cached results if a cache entry exists' {
+            InModuleScope 'PSKoans' -Parameters $testFile {
+                param($Script)
+                Invoke-Koan @{ Script = $Script; PassThru = $true }
+            } | Should -Be 'CachedResult'
+
+            Should -Invoke 'Get-KoanCachedResult'
+            Should -Invoke 'Add-KoanCachedResult' -Times 0
+        }
+    }
+
+    Context 'item does not exist in cache' {
+        It 'adds an item to the cache when the pester run is successful' {
+            InModuleScope 'PSKoans' -Parameters $testFile {
+                param($Script)
+                Invoke-Koan @{ Script = $Script; PassThru = $true }
+            }
+
+            Should -Invoke 'Get-KoanCachedResult'
+            Should -Invoke 'Add-KoanCachedResult'
+        }
     }
 }


### PR DESCRIPTION
# PR Summary

Fixes #457

## Context

This potentially fixes issue 457 by adding a caching mechanism. When a koan is evaluated for the first time the results of that evaluation are cached (as clixml). Clixml is used to attempt to ensure that error messages are presented in the same manner as a direct run.

This update changes the execution time of Measure-Karma to a fairly static value of around 2000ms which flucuates only based on the current in-progress topic.

Cached results are stored in ~\config\PSKoans\cache.

## Changes

- Adds new initialization script, InitializeCache.ps1
- Adds new private command: Add-KoanCachedResult
- Adds new private command: Get-KoanCachedResult
- Adds cache retrieval and addition to Invoke-Koan
- Fixes a bug in the Verbose output from Measure-Koan
- Propagates selection of pester version into the runspace created by New-KoanRunspace, ensures consistency in the version picker.

## Checklist

- [x] Pull Request has a meaningful title.
- [x] Summarised changes.
- [ ] Pull Request is ready to merge & is not WIP.
- [ ] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
